### PR TITLE
Fix java9 modules issue and --package command

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,6 +70,9 @@ val shadowJar by tasks.getting(ShadowJar::class) {
             into(archiveFile.get().asFile.parentFile)
         }
     }
+    manifest {
+        attributes("Main-Class" to "kscript.app.KscriptKt")
+    }
 }
 
 // Disable standard jar task to avoid building non-shadow jars

--- a/examples/httpClient.kts
+++ b/examples/httpClient.kts
@@ -1,0 +1,15 @@
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+
+/**
+ * Check Java 11 java.net.http module
+ */
+val client = HttpClient.newHttpClient()
+val request = HttpRequest.newBuilder()
+    .uri(URI("https://httpstat.us/418"))
+    .header("accept", "*/*")
+    .build()
+val response = client.send(request, HttpResponse.BodyHandlers.ofString())
+println("${response.statusCode()}| ${response.body()}")

--- a/src/main/kotlin/kscript/app/resolver/CommandResolver.kt
+++ b/src/main/kotlin/kscript/app/resolver/CommandResolver.kt
@@ -6,7 +6,6 @@ import kscript.app.model.Config
 import kscript.app.model.KotlinOpt
 import kscript.app.model.Script
 import java.nio.file.Path
-import java.nio.file.Paths
 import kotlin.io.path.absolute
 import kotlin.io.path.absolutePathString
 
@@ -23,18 +22,14 @@ class CommandResolver(private val config: Config, private val script: Script) {
     fun executeKotlin(jarArtifact: JarArtifact, dependencies: Set<Path>, userArgs: List<String>): String {
         val kotlinOptsStr = resolveKotlinOpts(script.kotlinOpts)
         val userArgsStr = resolveUserArgs(userArgs)
-        val scriptRuntime =
-            Paths.get("${config.kotlinHome}${config.separatorChar}lib${config.separatorChar}kotlin-script-runtime.jar")
-
         val dependenciesSet = buildSet<Path> {
             addAll(dependencies)
             add(jarArtifact.path)
-            add(scriptRuntime)
         }
 
         val classpath = resolveClasspath(dependenciesSet)
 
-        return "kotlin $kotlinOptsStr $classpath ${jarArtifact.execClassName} $userArgsStr"
+        return "java $kotlinOptsStr $classpath ${jarArtifact.execClassName} $userArgsStr"
     }
 
     fun interactiveKotlinRepl(dependencies: Set<Path>): String {

--- a/src/test/kotlin/kscript/app/KscriptKtTest.kt
+++ b/src/test/kotlin/kscript/app/KscriptKtTest.kt
@@ -1,0 +1,41 @@
+package kscript.app
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import assertk.assertions.startsWith
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.charset.Charset
+
+internal class KscriptKtTest {
+    @Test
+    fun test_main() {
+        val args = arrayOf(
+//            "--package",
+            "examples/httpClient.kts"
+        )
+
+        val (command, ex) = runScript(args)
+        assertThat(ex).isNull()
+        assertThat(command).startsWith("java")
+
+        val output = runCommand(command)
+        assertThat(output).isEqualTo("418| 418 I'm a teapot\n")
+    }
+
+    private fun runScript(args: Array<String>) = ByteArrayOutputStream().use { baos ->
+        val out = System.out
+        System.setOut(PrintStream(baos))
+        val e = kotlin.runCatching { main(args) }
+        System.setOut(out)
+        baos.toString(Charset.defaultCharset()) to e.exceptionOrNull()
+    }
+
+    private fun runCommand(cmd: String): String {
+        val process = ProcessBuilder().command(cmd.split(Regex("\\s+"))).start()
+        process.waitFor()
+        return process.inputStream.reader().readText()
+    }
+}


### PR DESCRIPTION
Hey!

I see you are doing redesign of kscript, so I want to submit my changes against your branch

 - `--package` command doesn't require gradle - IMO kscript must be self-sufficient, and gradle as dependency is overkill
 - compiled script is executed via `java` so all jre modules should be available (fixes https://github.com/holgerbrandl/kscript/issues/163)
 - add main class to kscript.jar manifest - probably, this should let to simplify launcher script (drop bash requirement)